### PR TITLE
Prototype failure for unsupported WASI functions

### DIFF
--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -252,26 +252,22 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_prestat_get(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_prestat_get(fd={:?}, buf={:#x?})", fd, buf);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_prestat_get(wasi_ctx, memory, fd, buf)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_prestat_dir_name(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_prestat_dir_name(fd={:?}, path={:#x?}, path_len={})", fd, path, path_len);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_prestat_dir_name(wasi_ctx, memory, fd, path, path_len)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_close(
@@ -284,16 +280,15 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_datasync(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_datasync(fd={:?})", fd);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        hostcalls::fd_datasync(wasi_ctx, fd)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_pread(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         iovs: wasm32::uintptr_t,
         iovs_len: wasm32::size_t,
@@ -308,21 +303,11 @@ syscalls! {
             offset,
             nread
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_pread(
-            wasi_ctx,
-            memory,
-            fd,
-            iovs,
-            iovs_len,
-            offset,
-            nread
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_pwrite(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         iovs: wasm32::uintptr_t,
         iovs_len: wasm32::size_t,
@@ -337,17 +322,7 @@ syscalls! {
             offset,
             nwritten
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_pwrite(
-            wasi_ctx,
-            memory,
-            fd,
-            iovs,
-            iovs_len,
-            offset,
-            nwritten
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_read(
@@ -380,7 +355,7 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_seek(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         offset: wasm32::__wasi_filedelta_t,
         whence: wasm32::__wasi_whence_t,
@@ -393,35 +368,29 @@ syscalls! {
             wasm32::whence_to_str(whence),
             newoffset
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_seek(wasi_ctx, memory, fd, offset, whence, newoffset)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_tell(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         newoffset: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_tell(fd={:?}, newoffset={:#x?})", fd, newoffset);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_tell(wasi_ctx, memory, fd, newoffset)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_fdstat_get(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_fdstat_get(fd={:?}, buf={:#x?})", fd, buf);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_fdstat_get(wasi_ctx, memory, fd, buf)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_fdstat_set_flags(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         flags: wasm32::__wasi_fdflags_t,
     ) -> wasm32::__wasi_errno_t {
@@ -430,12 +399,11 @@ syscalls! {
             fd,
             flags
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        hostcalls::fd_fdstat_set_flags(wasi_ctx, fd, flags)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_fdstat_set_rights(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         fs_rights_base: wasm32::__wasi_rights_t,
         fs_rights_inheriting: wasm32::__wasi_rights_t,
@@ -446,13 +414,7 @@ syscalls! {
             fs_rights_base,
             fs_rights_inheriting
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        hostcalls::fd_fdstat_set_rights(
-            wasi_ctx,
-            fd,
-            fs_rights_base,
-            fs_rights_inheriting
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_sync(
@@ -492,7 +454,7 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn fd_advise(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         offset: wasm32::__wasi_filesize_t,
         len: wasm32::__wasi_filesize_t,
@@ -505,8 +467,7 @@ syscalls! {
             len,
             advice
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        hostcalls::fd_advise(wasi_ctx,  fd, offset, len, advice)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_allocate(
@@ -521,7 +482,7 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn path_create_directory(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -532,13 +493,11 @@ syscalls! {
             path,
             path_len,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_create_directory(wasi_ctx, memory, fd, path, path_len)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_link(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd0: wasm32::__wasi_fd_t,
         flags0: wasm32::__wasi_lookupflags_t,
         path0: wasm32::uintptr_t,
@@ -557,25 +516,13 @@ syscalls! {
             path1,
             path_len1
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_link(
-            wasi_ctx,
-            memory,
-            fd0,
-            flags0,
-            path0,
-            path_len0,
-            fd1,
-            path1,
-            path_len1
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     // TODO: When multi-value happens, switch to that instead of passing
     // the `fd` by reference?
     pub unsafe extern "C" fn path_open(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         dirfd: wasm32::__wasi_fd_t,
         dirflags: wasm32::__wasi_lookupflags_t,
         path: wasm32::uintptr_t,
@@ -598,25 +545,11 @@ syscalls! {
             fs_flags,
             fd
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_open(
-            wasi_ctx,
-            memory,
-            dirfd,
-            dirflags,
-            path,
-            path_len,
-            oflags,
-            fs_rights_base,
-            fs_rights_inheriting,
-            fs_flags,
-            fd
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_readdir(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
         buf_len: wasm32::size_t,
@@ -631,21 +564,11 @@ syscalls! {
             cookie,
             buf_used,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_readdir(
-            wasi_ctx,
-            memory,
-            fd,
-            buf,
-            buf_len,
-            cookie,
-            buf_used
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_readlink(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -662,22 +585,11 @@ syscalls! {
             buf_len,
             buf_used,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_readlink(
-            wasi_ctx,
-            memory,
-            fd,
-            path,
-            path_len,
-            buf,
-            buf_len,
-            buf_used
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_rename(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd0: wasm32::__wasi_fd_t,
         path0: wasm32::uintptr_t,
         path_len0: wasm32::size_t,
@@ -694,33 +606,20 @@ syscalls! {
             path1,
             path_len1,
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_rename(
-            wasi_ctx,
-            memory,
-            fd0,
-            path0,
-            path_len0,
-            fd1,
-            path1,
-            path_len1
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_filestat_get(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         buf: wasm32::uintptr_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("fd_filestat_get(fd={:?}, buf={:#x?})", fd, buf);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::fd_filestat_get(wasi_ctx, memory, fd, buf)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_filestat_set_times(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         st_atim: wasm32::__wasi_timestamp_t,
         st_mtim: wasm32::__wasi_timestamp_t,
@@ -732,12 +631,11 @@ syscalls! {
             st_atim, st_mtim,
             fstflags
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        hostcalls::fd_filestat_set_times(wasi_ctx, fd, st_atim, st_mtim, fstflags)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn fd_filestat_set_size(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         size: wasm32::__wasi_filesize_t,
     ) -> wasm32::__wasi_errno_t {
@@ -746,12 +644,11 @@ syscalls! {
             fd,
             size
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        hostcalls::fd_filestat_set_size(wasi_ctx, fd, size)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_filestat_get(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         flags: wasm32::__wasi_lookupflags_t,
         path: wasm32::uintptr_t,
@@ -766,13 +663,11 @@ syscalls! {
             path_len,
             buf
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_filestat_get(wasi_ctx, memory, fd, flags, path, path_len, buf)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_filestat_set_times(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         flags: wasm32::__wasi_lookupflags_t,
         path: wasm32::uintptr_t,
@@ -790,23 +685,11 @@ syscalls! {
             st_atim, st_mtim,
             fstflags
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_filestat_set_times(
-            wasi_ctx,
-            memory,
-            fd,
-            flags,
-            path,
-            path_len,
-            st_atim,
-            st_mtim,
-            fstflags
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_symlink(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         path0: wasm32::uintptr_t,
         path_len0: wasm32::size_t,
         fd: wasm32::__wasi_fd_t,
@@ -821,21 +704,11 @@ syscalls! {
             path1,
             path_len1
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_symlink(
-            wasi_ctx,
-            memory,
-            path0,
-            path_len0,
-            fd,
-            path1,
-            path_len1
-        )
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_unlink_file(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -846,13 +719,11 @@ syscalls! {
             path,
             path_len
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_unlink_file(wasi_ctx, memory, fd, path, path_len)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn path_remove_directory(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         fd: wasm32::__wasi_fd_t,
         path: wasm32::uintptr_t,
         path_len: wasm32::size_t,
@@ -863,9 +734,7 @@ syscalls! {
             path,
             path_len
         );
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::path_remove_directory(wasi_ctx, memory, fd, path, path_len)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn poll_oneoff(
@@ -892,13 +761,11 @@ syscalls! {
     }
 
     pub unsafe extern "C" fn proc_raise(
-        vmctx: *mut VMContext,
+        _vmctx: *mut VMContext,
         sig: wasm32::__wasi_signal_t,
     ) -> wasm32::__wasi_errno_t {
         trace!("proc_raise(sig={:?})", sig);
-        let wasi_ctx = ok_or_errno!(get_wasi_ctx(&mut *vmctx));
-        let memory = ok_or_errno!(get_memory(&mut *vmctx));
-        hostcalls::proc_raise(wasi_ctx, memory, sig)
+        wasm32::__WASI_ENOSYS
     }
 
     pub unsafe extern "C" fn random_get(


### PR DESCRIPTION
A prototype failure case for a function we do not want implemented in Enarx's custom WASI implementation.

Instead of calling the syscall, the binding just returns the WASI `ENOSYS` error code.